### PR TITLE
libgeoip and ipinfo queries by LookupAsn

### DIFF
--- a/geoipdb.go
+++ b/geoipdb.go
@@ -51,12 +51,12 @@ func NewHandler() (Handler, error) {
 	return Handler{gi: gi}, nil
 }
 
-// GeoipLookup queries the libgeoip database for the ASN of a given ip address.
+// LibGeoipLookup queries the libgeoip database for the ASN of a given ip address.
 //
 // If found, returns
 // an ASN identification
 // and the corresponding description.
-func (h Handler) GeoipLookup(ip string) (string, string) {
+func (h Handler) LibGeoipLookup(ip string) (string, string) {
 	tmp, _ := h.gi.GetName(ip)
 	if tmp == "" {
 		return "", ""
@@ -75,7 +75,7 @@ func (h Handler) GeoipLookup(ip string) (string, string) {
 // an ASN identification
 // and the corresponding description.
 func (h Handler) LookupAsn(ip string) (string, string, error) {
-	asn, asnDescr := h.GeoipLookup(ip)
+	asn, asnDescr := h.LibGeoipLookup(ip)
 	if asn == "" {
 		return "", "", fmt.Errorf("unknown ASN for ip '%v'", ip)
 	}

--- a/geoipdb.go
+++ b/geoipdb.go
@@ -41,7 +41,20 @@ type Handler struct {
 	gip *geoip.GeoIP
 }
 
-// New creates and returns a geoipdb handler.
-func New() (Handler, error) {
-	return Handler{}, fmt.Errorf("not yet implemented")
+// NewHandler creates and returns a geoipdb handler.
+func NewHandler() (Handler, error) {
+	gip, err := geoip.OpenType(geoip.GEOIP_ASNUM_EDITION)
+	if err != nil {
+		return Handler{}, fmt.Errorf("cannot open GeoIP database: %s", err)
+	}
+	return Handler{gip: gip}, nil
+}
+
+// LookupAsn answers the Autonomous System Number (ASN) of a valid IP address.
+//
+// Returns
+// an ASN identification (eg "AS15169")
+// and the corresponding network name (eg. "Google Inc.").
+func (h Handler) LookupAsn(ip string) (string, string, error) {
+	return "", "", fmt.Errorf("not yet implemented")
 }

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -66,6 +66,14 @@ func TestLibGeoipLookup(t *testing.T) {
 	t.Logf("libgeoip results: %s %s", asn, asnDescr)
 }
 
+func TestIpInfoLookup(t *testing.T) {
+	asn, asnDescr, err := gh.IpInfoLookup(ip)
+	if err != nil {
+		t.Fatalf("IpInfoLookup failed: %s", err)
+	}
+	t.Logf("ipinfo.io results: %s %s", asn, asnDescr)
+}
+
 func TestLookupAsn(t *testing.T) {
 	asn, asnName, err := gh.LookupAsn(ip)
 	if err != nil {

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -58,8 +58,8 @@ func TestCreateHandler(t *testing.T) {
 	}
 }
 
-func TestGeoipLookup(t *testing.T) {
-	asn, asnDescr := gh.GeoipLookup(ip)
+func TestLibGeoipLookup(t *testing.T) {
+	asn, asnDescr := gh.LibGeoipLookup(ip)
 	if asn == "" {
 		t.Fatalf("ASN of ip '%s' is unknown by libgeoip", ip)
 	}

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -26,17 +26,37 @@
 package geoipdb_test
 
 import (
+	"net"
 	"testing"
 
 	"github.com/turbobytes/geoipdb"
 )
 
-var gip geoipdb.Handler
+var gh geoipdb.Handler
 
 func TestCreateHandler(t *testing.T) {
 	var err error
-	gip, err = geoipdb.New()
+	gh, err = geoipdb.NewHandler()
 	if err != nil {
 		t.Fatalf("geoipdb.New failed: %s", err)
 	}
+}
+
+func TestLookupAsn(t *testing.T) {
+	var err error
+	host := "www.turbobytes.com"
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		t.Fatalf("failed to lookup ip addresses for '%s': %s", host, err)
+	}
+	if len(ips) < 1 {
+		t.Fatalf("ip address lookup for '%s' returned empty", host)
+	}
+	ip := ips[0]
+	t.Logf("using ip %s (%s)", ip, host)
+	asn, asnName, err := gh.LookupAsn(ip.String())
+	if err != nil {
+		t.Fatalf("LookupAsn failed for ip %s: %s", ip, err)
+	}
+	t.Logf("%s (%v) is part of %s %s", host, ip, asn, asnName)
 }


### PR DESCRIPTION
Hi @sajal 

I requested this early pull request so you may want to take a look on how things are being implemented.

So far I added libgeoip and ipinfo specialized methods to geoipdb, as well as updated LookupAsn to use them. There are also simple tests for these methods:

```
$ go test -v
=== RUN   TestInitIp
--- PASS: TestInitIp (0.04s)
	geoipdb_test.go:48: using ip 107.20.181.99 (www.turbobytes.com) for tests
=== RUN   TestCreateHandler
--- PASS: TestCreateHandler (0.01s)
=== RUN   TestLibGeoipLookup
--- PASS: TestLibGeoipLookup (0.00s)
	geoipdb_test.go:66: libgeoip results: AS14618 Amazon.com, Inc.
=== RUN   TestIpInfoLookup
--- PASS: TestIpInfoLookup (0.40s)
	geoipdb_test.go:74: ipinfo.io results: AS14618 Amazon.com, Inc.
=== RUN   TestLookupAsn
--- PASS: TestLookupAsn (0.00s)
	geoipdb_test.go:82: LookupAsn results: AS14618 Amazon.com, Inc.
PASS
ok  	github.com/turbobytes/geoipdb	0.452s
```

Regards,
Rafael