### PR TITLE
Implement LookupAsn as a replacement of getasn in cnc.go

### DIFF
--- a/geoipdb.go
+++ b/geoipdb.go
@@ -133,7 +133,7 @@ func (h Handler) IpInfoLookup(ip string) (string, string, error) {
 		return "", "", fmt.Errorf("GET '%s' returned an empty answer", url)
 	}
 	answer := strings.SplitN(asnData, " ", 2)
-	// ipinfo.io returns errors as regular text (no outband error codes).
+	// ipinfo.io returns errors as regular text (no out-of-band error codes).
 	// Let's try to be smart and identify them.
 	if !reASN.MatchString(answer[0]) {
 		return "", "", fmt.Errorf("ipinfo.io lookup failed for '%s': %s", ip, asnData)
@@ -142,4 +142,12 @@ func (h Handler) IpInfoLookup(ip string) (string, string, error) {
 		return answer[0], "", nil
 	}
 	return answer[0], answer[1], nil
+}
+
+// CymruDnsLookup performs a query to Team Cymru's DNS service
+// for the description of a given ASN.
+//
+// Returns the ASN description.
+func (h Handler) CymruDnsLookup(asn string) (string, error) {
+	return "", fmt.Errorf("not yet implemented")
 }

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -35,6 +35,7 @@ import (
 const host = "www.turbobytes.com"
 
 var ip string
+var asn string
 
 func TestInitIp(t *testing.T) {
 	ips, err := net.LookupIP(host)
@@ -74,10 +75,22 @@ func TestIpInfoLookup(t *testing.T) {
 	t.Logf("ipinfo.io results: %s %s", asn, asnDescr)
 }
 
+func TestCymruDnsLookup(t *testing.T) {
+	//if asn == "" {
+		//t.Fatalf("missing asn")
+	//}
+	asnDescr, err := gh.CymruDnsLookup(asn)
+	if err != nil {
+		t.Fatalf("CymruDnsLookup failed: %s", err)
+	}
+	t.Logf("CymruDnsLookup results: %s", asnDescr)
+}
+
 func TestLookupAsn(t *testing.T) {
-	asn, asnName, err := gh.LookupAsn(ip)
+	asn, asnDescr, err := gh.LookupAsn(ip)
 	if err != nil {
 		t.Fatalf("LookupAsn failed for %s: %s", ip, err)
 	}
-	t.Logf("LookupAsn results: %s %s", asn, asnName)
+	t.Logf("LookupAsn results: %s %s", asn, asnDescr)
 }
+

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -35,7 +35,7 @@ import (
 const host = "www.turbobytes.com"
 
 var ip string
-var asn string
+var asnCymru string
 
 func TestInitIp(t *testing.T) {
 	ips, err := net.LookupIP(host)
@@ -64,6 +64,9 @@ func TestLibGeoipLookup(t *testing.T) {
 	if asn == "" {
 		t.Fatalf("ASN of ip '%s' is unknown by libgeoip", ip)
 	}
+	if asnCymru == "" {
+		asnCymru = asn
+	}
 	t.Logf("libgeoip results: %s %s", asn, asnDescr)
 }
 
@@ -72,16 +75,16 @@ func TestIpInfoLookup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("IpInfoLookup failed: %s", err)
 	}
+	if asnCymru == "" {
+		asnCymru = asn
+	}
 	t.Logf("ipinfo.io results: %s %s", asn, asnDescr)
 }
 
 func TestCymruDnsLookup(t *testing.T) {
-	//if asn == "" {
-		//t.Fatalf("missing asn")
-	//}
-	asnDescr, err := gh.CymruDnsLookup(asn)
+	asnDescr, err := gh.CymruDnsLookup(asnCymru)
 	if err != nil {
-		t.Fatalf("CymruDnsLookup failed: %s", err)
+		t.Fatalf("CymruDnsLookup failed for '%s': %s", asnCymru, err)
 	}
 	t.Logf("CymruDnsLookup results: %s", asnDescr)
 }
@@ -93,4 +96,3 @@ func TestLookupAsn(t *testing.T) {
 	}
 	t.Logf("LookupAsn results: %s %s", asn, asnDescr)
 }
-


### PR DESCRIPTION
@sajal LookupAsn does not implement cache nor queries to our own database yet (these will be further issues).

Fixes #1 