### PR TITLE
New Handler method AsnCacheList().

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -142,3 +142,18 @@ func (c cache) purgeAll() {
 		delete(c.asn, asn)
 	}
 }
+
+// asnList retrieves all ASNs known to the cache.
+//
+// Returns a non nil list of ASNs.
+func (c cache) asnList() []string {
+	c.RLock()
+	defer c.RUnlock()
+	answer := make([]string, len(c.asn))
+	var i int
+	for asn := range c.asn {
+		answer[i] = asn
+		i++
+	}
+	return answer
+}

--- a/geoipdb.go
+++ b/geoipdb.go
@@ -131,7 +131,7 @@ func (h Handler) LibGeoipLookup(ip string) (string, string) {
 // takes precedence for querying ASN descriptions.
 //
 // Data returned by LookupAsn is cached with a 1 day TTL.
-// Also see: PurgeAsnCache.
+// Also see: AsnCachePurge.
 //
 // Returns
 // an ASN identification
@@ -304,8 +304,8 @@ func (h Handler) getOverridenDescr(asn string, fallback string) string {
 	return descr
 }
 
-// PurgeAsnCache erases all LookupAsn cached data.
-func (h Handler) PurgeAsnCache() {
+// AsnCachePurge erases all LookupAsn cached data.
+func (h Handler) AsnCachePurge() {
 	log.Println("(geoipdb) cache purge")
 	h.cache.purgeAll()
 }
@@ -323,4 +323,11 @@ func (h Handler) LookupIp(asn string) []string {
 		i++
 	}
 	return answer
+}
+
+// AsnCacheList retrieves all ASNs known to the cache.
+//
+// Returns a non nil list of ASNs.
+func (h Handler) AsnCacheList() []string {
+	return h.cache.asnList()
 }

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -136,8 +136,8 @@ func TestLookupAsn(t *testing.T) {
 	verifyAsn(t, asnLookupAsn, asnDescr)
 }
 
-func TestPurgeAsnCache(t *testing.T) {
-	gh.PurgeAsnCache()
+func TestAsnCachePurge(t *testing.T) {
+	gh.AsnCachePurge()
 	TestLookupAsn(t)
 }
 
@@ -274,5 +274,13 @@ func TestLookupIp(t *testing.T) {
 	ips := gh.LookupIp(asnLookupAsn)
 	if !reflect.DeepEqual(ips, expected) {
 		t.Fatalf("LookupIp result mismatch for %s: expected %v, got %v", asnLookupAsn, expected, ips)
+	}
+}
+
+func TestAsnCacheList(t *testing.T) {
+	expected := []string{asnLookupAsn}
+	asns := gh.AsnCacheList()
+	if !reflect.DeepEqual(asns, expected) {
+		t.Fatalf("AsnCacheList result mismatch: expected %v, got %v", expected, asns)
 	}
 }


### PR DESCRIPTION
This new method exports the list of cached ASNs.

Fixes #20