### PR TITLE
Local network detection and IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # vim swap files
 .*.swp
+
+# test binary
+geoipdb.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get install -y libgeoip-dev
   # Install maxmind ASN database
   - wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+  - wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
   - gunzip *.dat.gz
   - sudo mkdir -p /usr/share/GeoIP/
   - sudo mv *.dat /usr/share/GeoIP/

--- a/cache.go
+++ b/cache.go
@@ -26,8 +26,8 @@
 package geoipdb
 
 import (
-	"time"
 	"sync"
+	"time"
 )
 
 // cacheTTL is the expiration time of a cache entry.
@@ -46,7 +46,7 @@ type cacheEntry struct {
 // cache allows manipulating cached data.
 type cache struct {
 	// Concurrent access control to maps
-	sync.RWMutex
+	*sync.RWMutex
 	// IP to ASN data
 	ip map[string]cacheEntry
 	// ASN to IP list
@@ -56,8 +56,9 @@ type cache struct {
 // newCache returns an empty initialized cache.
 func newCache() cache {
 	return cache{
-		ip:  make(map[string]cacheEntry),
-		asn: make(map[string]map[string]interface{}),
+		&sync.RWMutex{},
+		make(map[string]cacheEntry),
+		make(map[string]map[string]interface{}),
 	}
 }
 

--- a/geoipdb.go
+++ b/geoipdb.go
@@ -77,7 +77,7 @@ var (
 	// IPv6NotSupportedError is returned when IP parameter contains an IPv6 address.
 	IPv6NotSupportedError = errors.New("IPv6 not yet supported")
 	// PrivateIPError is returned on AS lookup of a private IP address.
-	PrivateIPError = errors.New("Private IP address")
+	PrivateIPError = errors.New("private IP address")
 )
 
 // Handler is a handler to TurboBytes GeoIP helper functions.

--- a/geoipdb.go
+++ b/geoipdb.go
@@ -310,9 +310,6 @@ func (cc cymruClient) lookup(asn string) (string, error) {
 	if asn == "" {
 		return "", fmt.Errorf("empty asn parameter")
 	}
-	if !reASN.MatchString(asn) {
-		log.Printf("warning: '%s' doesn't look a proper ASN identification.\n", asn)
-	}
 	if cc.dnsClient == nil {
 		return "", fmt.Errorf("cymruClient not initialized")
 	}

--- a/geoipdb.go
+++ b/geoipdb.go
@@ -42,8 +42,8 @@ see other Handler lookup methods.
 package geoipdb
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"

--- a/geoipdb.go
+++ b/geoipdb.go
@@ -126,11 +126,11 @@ func NewHandler(overrides *mgo.Collection, timeout time.Duration) (Handler, erro
 // and the corresponding description.
 func (h Handler) LibGeoipLookup(ip string) (string, string) {
 	var name string
-	ip_, is4 := iputils.ParseIP(ip)
-	if ip_ == nil {
+	ipAddr, isIPv4 := iputils.ParseIP(ip)
+	if ipAddr == nil {
 		return "", ""
 	}
-	if is4 {
+	if isIPv4 {
 		name, _ = h.geoip4.GetName(ip)
 	} else {
 		name, _ = h.geoip6.GetNameV6(ip)
@@ -162,11 +162,11 @@ func (h Handler) LibGeoipLookup(ip string) (string, string) {
 // and the corresponding description.
 func (h Handler) LookupAsn(ip string) (string, string, error) {
 	// Sanity check input
-	ip_, _ := iputils.ParseIP(ip)
-	if ip_ == nil {
+	ipAddr, _ := iputils.ParseIP(ip)
+	if ipAddr == nil {
 		return "", "", MalformedIPError
 	}
-	if iputils.IsLocalIP(ip_) {
+	if iputils.IsLocalIP(ipAddr) {
 		return "", "", PrivateIPError
 	}
 	// Try cache

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -287,7 +287,7 @@ func TestAsnCacheList(t *testing.T) {
 	}
 }
 
-func TestIsLocalIp(t *testing.T) {
+func TestIsLocalIP(t *testing.T) {
 	publicIps := []string{
 		"8.8.8.8",
 		"74.125.130.100",
@@ -305,12 +305,12 @@ func TestIsLocalIp(t *testing.T) {
 		"::1",
 	}
 	for _, ip := range publicIps {
-		if iputils.IsLocalIp(net.ParseIP(ip)) {
+		if iputils.IsLocalIP(net.ParseIP(ip)) {
 			t.Fatalf("IsLocalIp(%s) returned %s", ip, "true")
 		}
 	}
 	for _, ip := range privateIps {
-		if !iputils.IsLocalIp(net.ParseIP(ip)) {
+		if !iputils.IsLocalIP(net.ParseIP(ip)) {
 			t.Fatalf("IsLocalIp(%s) returned %s", ip, "false")
 		}
 	}

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -327,7 +327,8 @@ func TestLookupAsnMalformedIP(t *testing.T) {
 func TestLookupAsnIPv6(t *testing.T) {
 	ip := "fd07:a47c:3742:823e:3b02:76:982b:463"
 	_, _, err := gh.LookupAsn(ip)
-	if err != geoipdb.IPv6NotSupportedError {
+	if true {
+	//if err != geoipdb.IPv6NotSupportedError {
 		t.Fatalf("unexpected LookupAsn error: %v", err)
 	}
 }

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -325,10 +325,9 @@ func TestLookupAsnMalformedIP(t *testing.T) {
 }
 
 func TestLookupAsnIPv6(t *testing.T) {
-	ip := "fd07:a47c:3742:823e:3b02:76:982b:463"
+	ip := "2001:4860:1004::876:102"
 	_, _, err := gh.LookupAsn(ip)
-	if true {
-	//if err != geoipdb.IPv6NotSupportedError {
+	if err != nil {
 		t.Fatalf("unexpected LookupAsn error: %v", err)
 	}
 }
@@ -358,8 +357,8 @@ func TestLookupAsnOtherIPs(t *testing.T) {
 		ipTestData{"80.10.246.129", "", "", "unknown ASN for ip '80.10.246.129'"},
 		ipTestData{"127.0.0.1", "", "", "private IP address"},
 		ipTestData{"192.168.0.102", "", "", "private IP address"},
-		ipTestData{"2001:4860:1004::876:102", "", "", "IPv6 not yet supported"},
-		ipTestData{"2404:6800:4003:c01::64", "", "", "IPv6 not yet supported"},
+		ipTestData{"2001:4860:1004::876:102", "AS15169", "Google Inc.", ""},
+		ipTestData{"fc00::c01:64", "", "", "private IP address"},
 		ipTestData{"ns1.google.com", "", "", "malformed IP address"},
 		ipTestData{"ns2.google.com", "", "", "malformed IP address"},
 	}

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -315,3 +315,27 @@ func TestIsLocalIP(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupAsnMalformedIP(t *testing.T) {
+	ip := "192.168.0"
+	_, _, err := gh.LookupAsn(ip)
+	if err != geoipdb.MalformedIPError {
+		t.Fatalf("unexpected LookupAsn error: %v", err)
+	}
+}
+
+func TestLookupAsnIPv6(t *testing.T) {
+	ip := "fd07:a47c:3742:823e:3b02:76:982b:463"
+	_, _, err := gh.LookupAsn(ip)
+	if err != geoipdb.IPv6NotSupportedError {
+		t.Fatalf("unexpected LookupAsn error: %v", err)
+	}
+}
+
+func TestLookupAsnPrivateIP(t *testing.T) {
+	ip := "192.168.0.101"
+	_, _, err := gh.LookupAsn(ip)
+	if err != geoipdb.PrivateIPError {
+		t.Fatalf("unexpected LookupAsn error: %v", err)
+	}
+}

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -339,3 +339,45 @@ func TestLookupAsnPrivateIP(t *testing.T) {
 		t.Fatalf("unexpected LookupAsn error: %v", err)
 	}
 }
+
+type ipTestData struct {
+	ip    string
+	asn   string
+	descr string
+	err   string
+}
+
+func TestLookupAsnOtherIPs(t *testing.T) {
+	tests := []ipTestData{
+		ipTestData{"1.1.1.1", "AS15169", "Google Inc.", ""},
+		ipTestData{"8.8.8.8", "AS15169", "Google Inc.", ""},
+		ipTestData{"10.0.45.98", "", "", "private IP address"},
+		ipTestData{"74.125.130.100", "AS15169", "Google Inc.", ""},
+		ipTestData{"80.10.246.2", "", "", "unknown ASN for ip '80.10.246.2'"},
+		ipTestData{"80.10.246.129", "", "", "unknown ASN for ip '80.10.246.129'"},
+		ipTestData{"127.0.0.1", "", "", "private IP address"},
+		ipTestData{"192.168.0.102", "", "", "private IP address"},
+		ipTestData{"2001:4860:1004::876:102", "", "", "IPv6 not yet supported"},
+		ipTestData{"2404:6800:4003:c01::64", "", "", "IPv6 not yet supported"},
+		ipTestData{"ns1.google.com", "", "", "malformed IP address"},
+		ipTestData{"ns2.google.com", "", "", "malformed IP address"},
+	}
+	for _, test := range tests {
+		asn, descr, err := gh.LookupAsn(test.ip)
+		if asn != test.asn {
+			t.Fatalf("unexpected ASN returned by LookupAsn(\"%s\"): %s", test.ip, asn)
+		}
+		if descr != test.descr {
+			t.Fatalf("unexpected AS name returned by LookupAsn(\"%s\"): %s", test.ip, descr)
+		}
+		if err == nil {
+			if test.err != "" {
+				t.Fatalf("unexpected error returned by LookupAsn(\"%s\"): %s", test.ip, "nil")
+			}
+		} else {
+			if err.Error() != test.err {
+				t.Fatalf("unexpected error returned by LookupAsn(\"%s\"): %s", test.ip, err)
+			}
+		}
+	}
+}

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -349,7 +349,7 @@ type ipTestData struct {
 
 func TestLookupAsnOtherIPs(t *testing.T) {
 	tests := []ipTestData{
-		ipTestData{"1.1.1.1", "AS15169", "Google Inc.", ""},
+		ipTestData{"1.1.1.1", "", "", "unknown ASN for ip '1.1.1.1'"},
 		ipTestData{"8.8.8.8", "AS15169", "Google Inc.", ""},
 		ipTestData{"10.0.45.98", "", "", "private IP address"},
 		ipTestData{"74.125.130.100", "AS15169", "Google Inc.", ""},

--- a/geoipdb_test.go
+++ b/geoipdb_test.go
@@ -27,12 +27,14 @@ package geoipdb_test
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/turbobytes/geoipdb"
+	"github.com/turbobytes/geoipdb/iputils"
 	"gopkg.in/mgo.v2"
 )
 
@@ -282,5 +284,34 @@ func TestAsnCacheList(t *testing.T) {
 	asns := gh.AsnCacheList()
 	if !reflect.DeepEqual(asns, expected) {
 		t.Fatalf("AsnCacheList result mismatch: expected %v, got %v", expected, asns)
+	}
+}
+
+func TestIsLocalIp(t *testing.T) {
+	publicIps := []string{
+		"8.8.8.8",
+		"74.125.130.100",
+		"1.1.1.1",
+		"45.45.45.45",
+		"120.222.111.222",
+		"2404:6800:4003:c01::64",
+	}
+	privateIps := []string{
+		"127.0.0.1",
+		"10.5.6.4",
+		"192.168.5.99",
+		"100.66.55.66",
+		"fd07:a47c:3742:823e:3b02:76:982b:463",
+		"::1",
+	}
+	for _, ip := range publicIps {
+		if iputils.IsLocalIp(net.ParseIP(ip)) {
+			t.Fatalf("IsLocalIp(%s) returned %s", ip, "true")
+		}
+	}
+	for _, ip := range privateIps {
+		if !iputils.IsLocalIp(net.ParseIP(ip)) {
+			t.Fatalf("IsLocalIp(%s) returned %s", ip, "false")
+		}
 	}
 }

--- a/iputils/iputils.go
+++ b/iputils/iputils.go
@@ -116,3 +116,25 @@ func IsLocalIP(ip net.IP) bool {
 	}
 	return false
 }
+
+// IsIP4 tells if a string is an IPv4 address.
+func IsIP4(s string) bool {
+	_, answer := ParseIP(s)
+	return answer
+}
+
+// IsIP6 tells if a string is an IPv6 address.
+func isIP6(s string) bool {
+	ip, isV4 := ParseIP(s)
+	return ip != nil && !isV4
+}
+
+// ParseIP is a wrapper around net.ParseIP and net.IP.To4
+func ParseIP(s string) (ip net.IP, isIPv4 bool) {
+	ip = net.ParseIP(s)
+	if ip == nil {
+		return
+	}
+	isIPv4 = ip.To4() != nil
+	return
+}

--- a/iputils/iputils.go
+++ b/iputils/iputils.go
@@ -92,7 +92,7 @@ var nonGlobalIPv6CIDRs = []string{
 	"100::/64",      // Discard-Only Address Block, RFC6666
 }
 
-// IsLocalIP tells if an IP address is not forwardable beyond a network.
+// IsLocalIP tells if an IP address is not forwardable across networks.
 func IsLocalIP(ip net.IP) bool {
 	if ip == nil {
 		return true
@@ -117,16 +117,16 @@ func IsLocalIP(ip net.IP) bool {
 	return false
 }
 
-// IsIP4 tells if a string is an IPv4 address.
-func IsIP4(s string) bool {
+// IsIPv4 tells if a string is an IPv4 address.
+func IsIPv4(s string) bool {
 	_, answer := ParseIP(s)
 	return answer
 }
 
-// IsIP6 tells if a string is an IPv6 address.
-func isIP6(s string) bool {
-	ip, isV4 := ParseIP(s)
-	return ip != nil && !isV4
+// IsIPv6 tells if a string is an IPv6 address.
+func IsIPv6(s string) bool {
+	ip, isIPv4 := ParseIP(s)
+	return ip != nil && !isIPv4
 }
 
 // ParseIP is a wrapper around net.ParseIP and net.IP.To4

--- a/iputils/iputils.go
+++ b/iputils/iputils.go
@@ -117,6 +117,11 @@ func IsLocalIP(ip net.IP) bool {
 	return false
 }
 
+// IsIP tells if a string is an IP address.
+func IsIP(s string) bool {
+	return net.ParseIP(s) != nil
+}
+
 // IsIPv4 tells if a string is an IPv4 address.
 func IsIPv4(s string) bool {
 	_, answer := ParseIP(s)

--- a/iputils/iputils.go
+++ b/iputils/iputils.go
@@ -26,12 +26,89 @@
 package iputils
 
 import (
-	"log"
 	"net"
 )
 
-// IsLocalIp tells if an IP address is part of a private network.
-func IsLocalIp(ip net.IP) bool {
-	log.Println("warning: isLocalIp() not yet implemnted")
+func init() {
+	// Make sure nonGlobalIPv*CIDRs are parseable.
+	cidrs := append(nonGlobalIPv4CIDRs, nonGlobalIPv6CIDRs...)
+	for _, cidr := range cidrs {
+		_, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic("unparseable CIDR '" + cidr + "': " + err.Error())
+		}
+	}
+}
+
+// nonGlobalIPv4CIDRs contains IANA IPv4 Special-Purpose Address Registry,
+// where 'Global' flag is false.
+//
+// http://www.iana.org/assignments/iana-ipv4-special-registry/
+var nonGlobalIPv4CIDRs = []string{
+	"127.0.0.0/8",        // Loopback, RFC1122
+	"192.168.0.0/16",     // Private-Use, RFC1918
+	"10.0.0.0/8",         // Private-Use, RFC1918
+	"172.16.0.0/12",      // Private-Use, RFC1918
+	"0.0.0.0/8",          // "This host on this network", RFC1122 section 3.2.1.3
+	"100.64.0.0/10",      // Shared Address Space, RFC6598
+	"169.254.0.0/16",     // Link Local, RFC3927
+	"192.0.0.0/24",       // IETF Protocol Assignments, RFC6890
+	"192.0.2.0/24",       // Documentation (TEST-NET-1), RFC5737
+	"198.18.0.0/15",      // Benchmarking, RFC2544
+	"198.51.100.0/24",    // Documentation (TEST-NET-2), RFC5737
+	"203.0.113.0/24",     // Documentation (TEST-NET-3), RFC5737
+	"240.0.0.0/4",        // Reserved, RFC1112
+	"255.255.255.255/32", // Limited Broadcast, RFC919
+}
+
+// nonGlobalIPv6CIDRs contains IANA IPv6 Special-Purpose Address Registry,
+// where 'Global' flag is false.
+//
+// http://www.iana.org/assignments/iana-ipv6-special-registry/
+var nonGlobalIPv6CIDRs = []string{
+	"::1/128",       // Loopback Address, RFC4291
+	"fc00::/7",      // Unique-Local, RFC4193
+	"::ffff:0:0/96", // IPv4-mapped Address, RFC4291
+	"2001::/23",     // IETF Protocol Assignments, RFC2928
+	"fe80::/10",     // Linked-Scoped Unicast, RFC4291
+	"2001:db8::/32", // Documentation, RFC3849
+	"2001:2::/48",   // Benchmarking, RFC5180
+	"2001::/32",     // TEREDO, RFC4380
+	"100::/64",      // Discard-Only Address Block, RFC6666
+	"::/128",        // Unspecified Address, RFC4291
+}
+
+// IsLocalIP tells if an IP address is not forwardable beyond a network.
+//
+// Returns if the given IP address is local.
+func IsLocalIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	ip4 := ip.To4()
+	if ip4 != nil {
+		for _, cidr := range nonGlobalIPv4CIDRs {
+			_, inet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				continue
+			}
+			if inet.Contains(ip4) {
+				return true
+			}
+		}
+		return false
+	}
+	ip6 := ip.To16()
+	if ip6 != nil {
+		for _, cidr := range nonGlobalIPv6CIDRs {
+			_, inet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				continue
+			}
+			if inet.Contains(ip6) {
+				return true
+			}
+		}
+	}
 	return false
 }

--- a/iputils/iputils.go
+++ b/iputils/iputils.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 turbobytes
+//
+// This file is part of geoipdb, a library of GeoIP related helper functions
+// for TurboBytes stack.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package iputils
+
+import (
+	"log"
+	"net"
+)
+
+// IsLocalIp tells if an IP address is part of a private network.
+func IsLocalIp(ip net.IP) bool {
+	log.Println("warning: isLocalIp() not yet implemnted")
+	return false
+}


### PR DESCRIPTION
New [test cases](/turbobytes/geoipdb/blob/detect_private_network/geoipdb_test.go#L350) to tell private network apart from other types of failure are working fine.

This adds new error values to AsnLookup() only -- there is no change to geoipdb interface. CNC builds successfully with this merge.

Fixes #8 